### PR TITLE
Comment out useless macro definitions

### DIFF
--- a/vendor/common/crypto/mbedTLS/include/mbedtls/config.h
+++ b/vendor/common/crypto/mbedTLS/include/mbedtls/config.h
@@ -2433,7 +2433,7 @@
  *
  * This module requires: MBEDTLS_CHACHA20_C, MBEDTLS_POLY1305_C
  */
-#define MBEDTLS_CHACHAPOLY_C
+//#define MBEDTLS_CHACHAPOLY_C
 
 /**
  * \def MBEDTLS_CIPHER_C


### PR DESCRIPTION
Hi,There!
Maybe a useless macro definition should be commented out.
location:/BoAT-X-Framework/vendor/common/crypto/mbedTLS/include/mbedtls/config.h line2436,MBEDTLS_CHACHAPOLY_C